### PR TITLE
Fixes duplicate entry for key 'users_nickname_unique' error

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -70,7 +70,7 @@ class AuthController extends Controller
 
         $user = User::create([
             'email'    => $data['email'],
-            'nickname'    => $data['first_name'].'.'.$data['last_name'],
+            'nickname'    => $data['email'],
             'password' => bcrypt($data['password']),
             'role'     => $role
         ]);

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -70,6 +70,7 @@ class AuthController extends Controller
 
         $user = User::create([
             'email'    => $data['email'],
+            'nickname'    => $data['first_name'].'.'.$data['last_name'],
             'password' => bcrypt($data['password']),
             'role'     => $role
         ]);


### PR DESCRIPTION
When registering a second user, since the first user leaves nickname null, the second register will throw a duplicate unique key error.